### PR TITLE
Avoid preview releases and Browser's first run not completed

### DIFF
--- a/install-pwsh7.ps1
+++ b/install-pwsh7.ps1
@@ -12,7 +12,7 @@ Write-Host Create download url
 $downloadurl = "https://github.com/$repo/releases/download/$tag/$filename"
 Write-Host $download
 
-Write-host Download the PowerShell 7 MSI package
+Write-host Download the PowerShell 7 MSI package: $filename
 Invoke-WebRequest -Uri $downloadurl -OutFile $env:TEMP\$filename
 
 Write-host Install PowerShell 7

--- a/install-pwsh7.ps1
+++ b/install-pwsh7.ps1
@@ -3,7 +3,7 @@ $repo = "PowerShell/PowerShell"
 $releasesLatest = "https://api.github.com/repos/$repo/releases/latest"
 
 Write-Host Determining latest release
-$tag = (Invoke-WebRequest $releasesLatest | ConvertFrom-Json)[0].tag_name
+$tag = (Invoke-WebRequest $releasesLatest -UseBasicParsing| ConvertFrom-Json)[0].tag_name
 
 Write-Host Construct filename
 $filename = "Powershell-" + $tag.substring(1) + "-win-x64.msi"

--- a/install-pwsh7.ps1
+++ b/install-pwsh7.ps1
@@ -1,9 +1,9 @@
 Write-host Download latest Powershell 7 release from github
 $repo = "PowerShell/PowerShell"
-$releases = "https://api.github.com/repos/$repo/releases"
+$releasesLatest = "https://api.github.com/repos/$repo/releases/latest"
 
 Write-Host Determining latest release
-$tag = (Invoke-WebRequest $releases | ConvertFrom-Json)[0].tag_name
+$tag = (Invoke-WebRequest $releasesLatest | ConvertFrom-Json)[0].tag_name
 
 Write-Host Construct filename
 $filename = "Powershell-" + $tag.substring(1) + "-win-x64.msi"


### PR DESCRIPTION
PowerShell 7 has preview releases which should be avoid in regular productive servers.
Hence, I changed `$releases` to `$releasesLatest` and fetched the release tagged with "latest" label.
```pwsh
$releasesLatest = "https://api.github.com/repos/$repo/releases/latest"
```

When operating servers in shell, browser's first-run-experience is maybe not completed. This brings up an error on `Invoke-WebRequest` if parameter `-UseBasicParsing` is not passed.
Adding this to
```pwsh
$tag = (Invoke-WebRequest $releasesLatest -UseBasicParsing| ConvertFrom-Json)[0].tag_name
```
